### PR TITLE
Fix bug of month display.

### DIFF
--- a/DayDatePickerView.m
+++ b/DayDatePickerView.m
@@ -220,6 +220,7 @@
         columType = DayDatePickerViewColumnTypeDay;
     }
     else if(tableView == self.monthsTableView) {
+        dateComponents.day = 1;
         dateComponents.month = indexPath.row + 1;
         NSDate *date = [self.calendar dateFromComponents:dateComponents];
         cell.textLabel.text = [self.monthDateFormatter stringFromDate:date];


### PR DESCRIPTION
Fix bug of month display while selecting the specific day.
For example, 
the last day you choose is 5-31 and in June there is no 31st, so the month tableview will display the label "July" but not "June". (the NSCalendar)
